### PR TITLE
Make installation work as commonly expected

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ RM ?= rm -f
 
 CFLAGS += -O2 -Wall -Wextra -Wno-missing-field-initializers
 
-PREFIX = ~/bin
+PREFIX ?= /usr/bin
+DESTDIR ?= /
 
 .SUFFIXES:.o
 .c.o:
@@ -26,7 +27,7 @@ clean:
 	$(RM) $(PROGRAM) version.h $(OBJS)
 
 install: $(PROGRAM)
-	install -d $(PREFIX)
-	install $(PROGRAM) $(PREFIX)/$(PROGRAM)
+	install -d $(DESTDIR)/$(PREFIX)
+	install $(PROGRAM) $(DESTDIR)/$(PREFIX)/$(PROGRAM)
 
 .PHONY: clean all


### PR DESCRIPTION
This commit improves the Makefile in two ways:
* It introduces a 'DESTDIR' option and changes the behavior of the 'PREFIX' option as commonly expected (c.f. https://stackoverflow.com/questions/11307465/destdir-and-prefix-of-make).
* It makes both the new 'DESTDIR' option and the existing 'PREFIX' option assignable through an environment variable.